### PR TITLE
Add ssh options for agent and x11 forward

### DIFF
--- a/sshfs.c
+++ b/sshfs.c
@@ -306,6 +306,8 @@ static const char *ssh_opts[] = {
 	"ConnectTimeout",
 	"ControlMaster",
 	"ControlPath",
+	"ForwardAgent",
+	"ForwardX11",
 	"GlobalKnownHostsFile",
 	"GSSAPIAuthentication",
 	"GSSAPIDelegateCredentials",


### PR DESCRIPTION
For some reason, sshfs starts xquartz on my mac. Adding the forwardx11 option for explicitly disabling it, and the forwardagent while we're at it for people using the controlmaster stuff.