### PR TITLE
MacOS speedup on read 

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -1,0 +1,47 @@
+#! /bin/sh
+
+DIE=0
+
+(autoconf --version) < /dev/null > /dev/null 2>&1 || {
+    echo
+        echo "You must have autoconf installed."
+	DIE=1
+}
+
+# libtool --version check not done...
+
+(automake --version) < /dev/null > /dev/null 2>&1 || {
+    echo
+        echo "You must have automake installed."
+        DIE=1
+}
+
+if test "$DIE" -eq 1; then
+    exit 1
+fi
+
+echo Removing old files...
+rm -f stamp-h1 configure Makefile Makefile.in src/Makefile src/Makefile.in config.h config.status aclocal.m4 config.cache config.log
+[ -d "config" ] &&  rm -rf config
+[ -d "autom4te.cache" ] &&  rm -rf autom4te.cache
+mkdir config
+
+echo "aclocal -I ."
+aclocal -I . 
+if test $? -ne 0; then
+    exit 1
+fi
+echo "autoheader"
+autoheader
+if test $? -ne 0; then
+    exit 1
+fi
+echo "automake --foreign --add-missing"
+automake --foreign --add-missing
+if test $? -ne 0; then
+    exit 1
+fi
+echo "autoconf"
+autoconf
+echo "BOOTSTRAP complete"
+

--- a/sshfs.c
+++ b/sshfs.c
@@ -1824,7 +1824,9 @@ static void *sshfs_init(void)
 #if FUSE_VERSION >= 26
 	/* Readahead should be done by kernel or sshfs but not both */
 	if (conn->async_read)
-		sshfs.sync_read = 1;
+		// Force async even if kernel claims its doing async.
+		// MacOS, see https://github.com/osxfuse/sshfs/issues/57
+		sshfs.sync_read = 0;
 #endif
 
 	if (!sshfs.delay_connect)


### PR DESCRIPTION
(workaround for kernel reporting async but only doing sync reads.  force sshfs to do async-reads).