### PR TITLE
Fix fuse include for apple silicon

### DIFF
--- a/sshfs.c
+++ b/sshfs.c
@@ -15,7 +15,11 @@
 #include <fuse_lowlevel.h>
 #endif
 #ifdef __APPLE__
-#  include <fuse_darwin.h>
+#  if defined(__aarch64__)
+#    include <fuse.h>
+#  else
+#    include <fuse_darwin.h>
+#  endif
 #endif
 #include <assert.h>
 #include <stdio.h>


### PR DESCRIPTION
Thanks for developing this. Macfuse/sshfs is a big part of my workflow. I recently got a new Apple Silicon laptop and couldn't install sshfs from homebrew. Building from source didn't work either because of the `fuse_darwin.h` include.

## Change
  - Conditionally `#include <fuse.h>` if we're compiling for Apple Silicon
  
## Verification
  - Builds, installs and mounts volumes on MacBook M3 exactly as before 😄 